### PR TITLE
Allow undefined in getUserByNetID

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   singleQuote: true,
   trailingComma: 'es5',
+  semi: true
 };

--- a/src/repos/ClubRepo.ts
+++ b/src/repos/ClubRepo.ts
@@ -18,11 +18,8 @@ const createClub = async (name: string): Promise<void> => {
   return;
 };
 
-const getClubByName = async (name: string): Promise<Club> => {
+const getClubByName = async (name: string): Promise<Club | undefined> => {
   const club = await db().findOne({ where: { name } });
-  if (!club) {
-    throw Error('Club with that name not found');
-  }
   return club;
 };
 

--- a/src/repos/CornellMajorRepo.ts
+++ b/src/repos/CornellMajorRepo.ts
@@ -18,11 +18,8 @@ const createCornellMajor = async (name: string): Promise<void> => {
   return;
 };
 
-const getCornellMajorByName = async (name: string): Promise<CornellMajor> => {
+const getCornellMajorByName = async (name: string): Promise<CornellMajor | undefined> => {
   const major = await db().findOne({ where: { name } });
-  if (!major) {
-    throw Error('CornellMajor with that name not found');
-  }
   return major;
 };
 

--- a/src/repos/InterestRepo.ts
+++ b/src/repos/InterestRepo.ts
@@ -18,11 +18,8 @@ const createInterest = async (name: string): Promise<void> => {
   return;
 };
 
-const getInterestByName = async (name: string): Promise<Interest> => {
+const getInterestByName = async (name: string): Promise<Interest | undefined> => {
   const interest = await db().findOne({ where: { name } });
-  if (!interest) {
-    throw Error('Interest with that name not found');
-  }
   return interest;
 };
 

--- a/src/repos/MatchingRepo.ts
+++ b/src/repos/MatchingRepo.ts
@@ -1,5 +1,4 @@
 import { getConnectionManager, Repository } from 'typeorm';
-import Constants from '../common/constants';
 import DaySchedule from '../entities/DaySchedule';
 import Matching from '../entities/Matching';
 import Time from '../entities/Time';
@@ -23,9 +22,6 @@ const userDB = (): Repository<User> =>
     .getRepository(User);
 
 const createTime = async (time: number): Promise<void> => {
-  if (!Constants.VALID_TIMES.includes(time)) {
-    throw Error('Invalid time');
-  }
   const possibleTime = await timeDB().findOne({ time });
   if (!possibleTime) {
     const timeObj = timeDB().create({
@@ -39,23 +35,13 @@ const createDaySchedule = async (
   day: string,
   times: number[]
 ): Promise<DaySchedule> => {
-  if (!Constants.VALID_DAYS.includes(day)) {
-    throw Error(
-      'Invalid day ' + day + ' is not in [' + Constants.VALID_DAYS + ']'
-    );
-  }
   const daySchedule = dayScheduleDB().create({
     day,
     times: [],
   });
   for await (const time of times) {
-    if (!Constants.VALID_TIMES.includes(time)) {
-      throw Error(
-        'Invalid time ' + time + ' is not in [' + Constants.VALID_TIMES + ']'
-      );
-    }
     const timeObj = await timeDB().findOne({ time });
-    if (!timeObj) throw new Error('Internal error');
+    if (!timeObj) throw Error('Internal error');
     daySchedule.times.push(timeObj);
     await timeDB().save(timeObj);
   }

--- a/src/repos/UserRepo.ts
+++ b/src/repos/UserRepo.ts
@@ -44,19 +44,6 @@ const updateUser = async (
   user: User,
   userFields: UserUpdateFields
 ): Promise<boolean> => {
-  const userFieldKeys = Object.keys(userFields);
-  if (userFieldKeys.length < 1) {
-    throw Error('At least one user field is required');
-  }
-  for (const key of userFieldKeys) {
-    if (
-      !Object.keys(user).includes(key) ||
-      key === 'googleID' ||
-      key === 'netID'
-    ) {
-      throw Error('Invalid user field provided: ' + key);
-    }
-  }
   db().merge(user, userFields);
   await db().save(user);
   return true;

--- a/src/repos/UserRepo.ts
+++ b/src/repos/UserRepo.ts
@@ -62,7 +62,7 @@ const updateUser = async (
   return true;
 };
 
-const getUserByNetID = async (netID: string): Promise<User> => {
+const getUserByNetID = async (netID: string): Promise<User | undefined> => {
   const user = await db().findOne({
     where: { netID },
     relations: [
@@ -75,9 +75,6 @@ const getUserByNetID = async (netID: string): Promise<User> => {
       'major',
     ],
   });
-  if (!user) {
-    throw Error('User with given netID not found');
-  }
   return user;
 };
 

--- a/src/repos/UserSessionRepo.ts
+++ b/src/repos/UserSessionRepo.ts
@@ -76,18 +76,15 @@ const createUserAndInitializeSession = async (
 /**
  * Get user from access token
  * @param {string} accessToken - Access token that we want to find the owner
- * @return {User} User that is associated with the access token
+ * @return {User | undefined} User that is associated with the access token. Undefined if not found.
  */
-const getUserFromToken = async (accessToken: string): Promise<User> => {
+const getUserFromToken = async (accessToken: string): Promise<User | undefined> => {
   const session = await db()
     .createQueryBuilder('usersessions')
     .leftJoinAndSelect('usersessions.user', 'user')
     .where('usersessions.accessToken = :accessToken', { accessToken })
     .getOne();
-  if (!session) {
-    throw Error('No session found with valid token');
-  }
-  return session.user;
+  return session?.user;
 };
 
 const updateSession = async (

--- a/src/repos/UserSessionRepo.ts
+++ b/src/repos/UserSessionRepo.ts
@@ -1,4 +1,4 @@
-import { getConnectionManager, Repository, getRepository } from 'typeorm';
+import { getConnectionManager, Repository } from 'typeorm';
 import { LoginTicket } from 'google-auth-library/build/src/auth/loginticket';
 import { SerializedUserSession } from '../common/types';
 import AppDevUtils from '../utils/AppDevUtils';
@@ -7,9 +7,7 @@ import User from '../entities/User';
 import UserSession from '../entities/UserSession';
 
 const db = (): Repository<UserSession> =>
-  getConnectionManager()
-    .get()
-    .getRepository(UserSession);
+  getConnectionManager().get().getRepository(UserSession);
 
 /**
  * Create or update session for a user

--- a/src/routers/CreateMatchingRouter.ts
+++ b/src/routers/CreateMatchingRouter.ts
@@ -1,8 +1,10 @@
 import { Request } from 'express';
 import { SerializedMatching } from '../common/types';
 import AuthenticatedAppplicationRouter from '../utils/AuthenticatedApplicationRouter';
+import Constants from '../common/constants';
 import MatchingRepo from '../repos/MatchingRepo';
 import UserRepo from '../repos/UserRepo';
+
 class CreateMatchingRouter extends AuthenticatedAppplicationRouter<
   SerializedMatching
 > {
@@ -18,6 +20,18 @@ class CreateMatchingRouter extends AuthenticatedAppplicationRouter<
     const { netIDs, schedule } = req.body;
     const daySchedules = [];
     for (const ds of schedule) {
+      if (!Constants.VALID_DAYS.includes(ds.day)) {
+        throw Error(
+          'Invalid day ' + ds.day + ' is not in [' + Constants.VALID_DAYS + ']'
+        );
+      }
+      for (const time of ds.times) {
+        if (!Constants.VALID_TIMES.includes(time)) {
+          throw Error(
+            'Invalid time ' + time + ' is not in [' + Constants.VALID_TIMES + ']'
+          );
+        }
+      }
       const daySchedule = await MatchingRepo.createDaySchedule(
         ds.day,
         ds.times

--- a/src/routers/GetUserRouter.ts
+++ b/src/routers/GetUserRouter.ts
@@ -15,6 +15,7 @@ class GetUserRouter extends AuthenticatedAppplicationRouter<SerializedUser> {
   async content(req: Request): Promise<SerializedUser> {
     const { netID } = req.query;
     const user = await UserRepo.getUserByNetID(netID);
+    if (!user) throw Error('User with that netID does not exist');
     return user.serialize();
   }
 }

--- a/src/utils/AppDevUtils.ts
+++ b/src/utils/AppDevUtils.ts
@@ -8,11 +8,11 @@
  */
 const tryCheckAppDevURL = (path: string) => {
   if (path !== '/' && path.length < 2) {
-    throw new Error('Invalid path');
+    throw Error('Invalid path');
   } else if (path[0] !== '/') {
-    throw new Error("Path must start with a '/'");
+    throw Error("Path must start with a '/'");
   } else if (path[path.length - 1] !== '/') {
-    throw new Error("Path must end with a '/'");
+    throw Error("Path must end with a '/'");
   }
 };
 

--- a/src/utils/ApplicationRouter.ts
+++ b/src/utils/ApplicationRouter.ts
@@ -54,7 +54,7 @@ class ApplicationRouter<T> {
         this.router.delete(path, this.response());
         break;
       default:
-        throw new Error('HTTP method not specified!');
+        throw Error('HTTP method not specified!');
     }
   }
 
@@ -63,7 +63,7 @@ class ApplicationRouter<T> {
    * be an AppDev-formatted URL
    */
   getPath(): string {
-    throw new Error('You must implement getPath() with a valid path!');
+    throw Error('You must implement getPath() with a valid path!');
   }
 
   middleware(): any[] {
@@ -75,7 +75,7 @@ class ApplicationRouter<T> {
    * for the given request.
    */
   async content(req: Request): Promise<T> {
-    throw new Error('You must implement content()!');
+    throw Error('You must implement content()!');
   }
 
   /**

--- a/src/utils/Authenticate.ts
+++ b/src/utils/Authenticate.ts
@@ -39,6 +39,7 @@ async function ensureAuthenticated(
       .json(new AppDevResponse(false, { errors: ['Invalid access token'] }));
   }
   const user = await UserSessionRepo.getUserFromToken(bearerToken);
+  if (!user) throw Error('No user found with valid access token');
   req.user = user;
   return next();
 }


### PR DESCRIPTION
## Overview
This started as a bug fix for the login flow. `getUserByNetID(netID: string): User` should have been of type `getUserByNetID(netID: string): User | undefined` because it allows you to see if a user already exists or not with the given `netID`. This was the assumed functionality in `UserSessionRepo` and `CreateMatchingRouter` causing some bugs. 

To maintain consistency, errors are now thrown from routers when using DAO functions.

## Changes Made
Originally, only the `UserRepo` was changed so that it does not throw an error and instead returns a `User | undefined`. `GetUserRouter` was changed to see if a user with a given netID exists in the router itself.

Routers are now responsible for checking errors with DAO functions rather than the functions themselves. The routers that were changed are `UpdateUserRouter`, `GetUserRouter`, and `CreateMatchingRouter`.