### PR TITLE
Refactor user entity and add dev endpoint for user creation

### DIFF
--- a/src/API.ts
+++ b/src/API.ts
@@ -12,6 +12,7 @@ import HelloRouter from './routers/HelloRouter';
 import InitializeSessionRouter from './routers/InitializeSessionRouter';
 import RefreshSessionRouter from './routers/RefreshSessionRouter';
 import UpdateUserRouter from './routers/UpdateUserRouter';
+import InitializeDevSessionRouter from './routers/InitializeDevSessionRouter';
 
 class API extends ApplicationAPI {
   getPath(): string {
@@ -29,7 +30,7 @@ class API extends ApplicationAPI {
 
   routerGroups(): { [index: string]: Router[] } {
     return {
-      auth: [InitializeSessionRouter],
+      auth: [InitializeSessionRouter, InitializeDevSessionRouter],
       docs: [DocsRouter],
       general: [HelloRouter],
       refresh: [RefreshSessionRouter],

--- a/src/API.ts
+++ b/src/API.ts
@@ -30,7 +30,8 @@ class API extends ApplicationAPI {
 
   routerGroups(): { [index: string]: Router[] } {
     return {
-      auth: [InitializeSessionRouter, InitializeDevSessionRouter],
+      auth: [InitializeSessionRouter],
+      dev: [InitializeDevSessionRouter],
       docs: [DocsRouter],
       general: [HelloRouter],
       refresh: [RefreshSessionRouter],

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -26,7 +26,10 @@ const VALID_TIMES = [
   20.5,
 ];
 
+const UNDECLARED_MAJOR = 'Undeclared';
+
 export default {
   VALID_DAYS,
   VALID_TIMES,
+  UNDECLARED_MAJOR,
 };

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -4,34 +4,35 @@ import CornellMajor from '../entities/CornellMajor';
 
 //** Represents a User */
 export interface SerializedUser {
-  clubs: SerializedClub[];
-  facebook: string | null;
-  firstName: string;
   googleID: string;
-  graduationYear: string | null;
-  hometown: string | null;
-  instagram: string | null;
-  interests: SerializedInterest[];
+  firstName: string;
   lastName: string;
   netID: string;
-  major: SerializedCornellMajor | null;
-  matches: SubSerializedMatching[];
-  profilePictureURL: string | null;
   pronouns: string | null;
+  graduationYear: string | null;
+  major: SerializedCornellMajor | null;
+  hometown: string | null;
+  clubs: SerializedClub[];
+  interests: SerializedInterest[];
+  facebook: string | null;
+  instagram: string | null;
+  profilePictureURL: string | null;
+  matches: SubSerializedMatching[];
 }
 
 //** Represents a User without clubs, interests, majors, or matches shown */
 export interface SubSerializedUser {
-  facebook: string | null;
-  firstName: string;
   googleID: string;
-  graduationYear: string | null;
-  hometown: string | null;
-  instagram: string | null;
+  firstName: string;
   lastName: string;
   netID: string;
-  profilePictureURL: string | null;
   pronouns: string | null;
+  graduationYear: string | null;
+  major: SerializedCornellMajor | null;
+  hometown: string | null;
+  facebook: string | null;
+  instagram: string | null;
+  profilePictureURL: string | null;
 }
 
 //** Represents a User session */
@@ -75,15 +76,15 @@ export type SerializedCornellMajor = string;
 export type SerializedInterest = string;
 
 export interface UserUpdateFields {
-  clubs?: Club[];
-  facebook?: string;
   firstName?: string;
-  graduationYear?: string;
-  hometown?: string;
-  interests?: Interest[];
-  instagram?: string;
   lastName?: string;
-  major?: CornellMajor;
-  profilePictureURL?: string;
   pronouns?: string;
+  graduationYear?: string;
+  major?: CornellMajor;
+  hometown?: string;
+  clubs?: Club[];
+  interests?: Interest[];
+  facebook?: string;
+  instagram?: string;
+  profilePictureURL?: string;
 }

--- a/src/entities/User.ts
+++ b/src/entities/User.ts
@@ -5,6 +5,7 @@ import {
   ManyToMany,
   ManyToOne,
 } from 'typeorm';
+import constants from '../common/constants';
 import { SerializedUser, SubSerializedUser } from '../common/types';
 import Club from './Club';
 import CornellMajor from './CornellMajor';
@@ -14,133 +15,110 @@ import Matching from './Matching';
 @Entity('pear_user')
 class User {
   @PrimaryGeneratedColumn('uuid')
-  id: string;
-
-  /** User's clubs */
-  @ManyToMany(
-    type => Club,
-    club => club.users
-  )
-  clubs: Club[];
-
-  /** User's facebook profile link */
-  @Column({
-    type: 'varchar',
-    nullable: true,
-  })
-  facebook: string | null;
-
-  /** User first name */
-  @Column({
-    type: 'varchar',
-  })
-  firstName: string;
+  uuid: string;
 
   /** Google ID of user */
-  @Column({
-    type: 'varchar',
-  })
+  @Column({ type: 'varchar' })
   googleID: string;
 
-  /** User's graduation year */
-  @Column({
-    type: 'varchar',
-    nullable: true,
-  })
-  graduationYear: string | null;
-
-  /** User's hometown */
-  @Column({
-    type: 'varchar',
-    nullable: true,
-  })
-  hometown: string | null;
-
-  /** User's instagram username */
-  @Column({
-    type: 'varchar',
-    nullable: true,
-  })
-  instagram: string | null;
-
-  /** User's interests */
-  @ManyToMany(
-    type => Interest,
-    interest => interest.users
-  )
-  interests: Interest[];
+  /** User first name */
+  @Column({ type: 'varchar' })
+  firstName: string;
 
   /** User last name */
-  @Column({
-    type: 'varchar',
-  })
+  @Column({ type: 'varchar' })
   lastName: string;
 
   /** Net ID of user */
-  @Column({
-    type: 'varchar',
-  })
+  @Column({ type: 'varchar' })
   netID: string;
 
+  /** User's pronouns */
+  @Column({ type: 'varchar', nullable: true })
+  pronouns: string | null;
+
+  /** User's graduation year */
+  @Column({ type: 'varchar', nullable: true })
+  graduationYear: string | null;
+
   /** User's major */
-  @ManyToOne(
-    type => CornellMajor,
-    major => major.users,
-    { nullable: true }
-  )
+  @ManyToOne(type => CornellMajor, major => major.users, { nullable: true })
   major: CornellMajor | null;
 
-  /** User's matchings */
-  @ManyToMany(
-    type => Matching,
-    matching => matching.users
-  )
-  matches: Matching[];
+  /** User's hometown */
+  @Column({ type: 'varchar', nullable: true })
+  hometown: string | null;
 
-  @Column({
-    type: 'varchar',
-    nullable: true,
-  })
+  /** User's clubs */
+  @ManyToMany(type => Club, club => club.users)
+  clubs: Club[];
+
+  /** User's interests */
+  @ManyToMany(type => Interest, interest => interest.users)
+  interests: Interest[];
+
+  /** User's facebook profile link */
+  @Column({ type: 'varchar', nullable: true })
+  facebook: string | null;
+
+  /** User's instagram username */
+  @Column({ type: 'varchar', nullable: true })
+  instagram: string | null;
+
+  @Column({ type: 'varchar', nullable: true })
   profilePictureURL: string | null;
 
-  /** User's pronouns */
-  @Column({
-    type: 'varchar',
-    nullable: true,
-  })
-  pronouns: string | null;
+  /** User's matchings */
+  @ManyToMany(type => Matching, matching => matching.users)
+  matches: Matching[];
+
+  /**
+   * Method to create a dummy user. (For testing purposes)
+   * @function
+   * @param {string} id - google id used to create new user
+   * @return {User} a new user with supplied google id
+   */
+  static dummy(id: string): User {
+    const user = new User();
+    user.googleID = id;
+    user.firstName = 'Chuck';
+    user.lastName = 'Norris';
+    user.netID = 'cnorris';
+    return user;
+  }
 
   serialize(): SerializedUser {
     return {
-      clubs: this.clubs.map(club => club.serialize()),
-      facebook: this.facebook,
-      firstName: this.firstName,
       googleID: this.googleID,
-      graduationYear: this.graduationYear,
-      hometown: this.hometown,
-      instagram: this.instagram,
-      interests: this.interests.map(interest => interest.serialize()),
+      firstName: this.firstName,
       lastName: this.lastName,
       netID: this.netID,
-      major: this.major ? this.major.serialize() : null,
-      matches: this.matches.map(match => match.subSerialize()),
-      profilePictureURL: this.profilePictureURL,
       pronouns: this.pronouns,
+      graduationYear: this.graduationYear,
+      major: this.major ? this.major.serialize() : constants.UNDECLARED_MAJOR,
+      hometown: this.hometown,
+      clubs: this.clubs ? this.clubs.map(club => club.serialize()) : [],
+      interests: this.interests ? this.interests.map(interest => interest.serialize()) : [],
+      facebook: this.facebook,
+      instagram: this.instagram,
+      profilePictureURL: this.profilePictureURL,
+      matches: this.matches ? this.matches.map(match => match.subSerialize()) : [],
     };
   }
 
   subSerialize(): SubSerializedUser {
     return {
-      facebook: this.facebook,
-      firstName: this.firstName,
       googleID: this.googleID,
-      graduationYear: this.graduationYear,
-      hometown: this.hometown,
-      instagram: this.instagram,
+      firstName: this.firstName,
       lastName: this.lastName,
       netID: this.netID,
-      profilePictureURL: this.profilePictureURL,
       pronouns: this.pronouns,
+      graduationYear: this.graduationYear,
+      major: this.major ? this.major.serialize() : constants.UNDECLARED_MAJOR,
+      hometown: this.hometown,
+      facebook: this.facebook,
+      instagram: this.instagram,
+      profilePictureURL: this.profilePictureURL,
     };
   }
 }

--- a/src/entities/User.ts
+++ b/src/entities/User.ts
@@ -30,7 +30,7 @@ class User {
   lastName: string;
 
   /** Net ID of user */
-  @Column({ type: 'varchar' })
+  @Column({ type: 'varchar', unique: true })
   netID: string;
 
   /** User's pronouns */
@@ -42,7 +42,7 @@ class User {
   graduationYear: string | null;
 
   /** User's major */
-  @ManyToOne(type => CornellMajor, major => major.users, { nullable: true })
+  @ManyToOne(type => CornellMajor, major => major.users, { nullable: true, onDelete: "CASCADE" })
   major: CornellMajor | null;
 
   /** User's hometown */
@@ -50,11 +50,11 @@ class User {
   hometown: string | null;
 
   /** User's clubs */
-  @ManyToMany(type => Club, club => club.users)
+  @ManyToMany(type => Club, club => club.users, { onDelete: "CASCADE" })
   clubs: Club[];
 
   /** User's interests */
-  @ManyToMany(type => Interest, interest => interest.users)
+  @ManyToMany(type => Interest, interest => interest.users, { onDelete: "CASCADE" })
   interests: Interest[];
 
   /** User's facebook profile link */

--- a/src/entities/UserSession.ts
+++ b/src/entities/UserSession.ts
@@ -45,7 +45,7 @@ class UserSession {
   refreshToken: string;
 
   /** User that the session belongs to */
-  @OneToOne(type => User)
+  @OneToOne(type => User, { onDelete: "CASCADE" })
   @JoinColumn()
   user: User;
 

--- a/src/repos/UserRepo.ts
+++ b/src/repos/UserRepo.ts
@@ -1,13 +1,29 @@
 import { getConnectionManager, Repository } from 'typeorm';
 import { UserUpdateFields } from '../common/types';
 import User from '../entities/User';
+import LogUtils from '../utils/LogUtils';
 
 const db = (): Repository<User> =>
   getConnectionManager()
     .get()
     .getRepository(User);
 
-const initalizeUser = async (
+/**
+* Creates a dummy user and saves it to the db (Testing purposes)
+* @function
+* @param {string} id - Google id to create user with
+* @return {User} New dummy user
+*/
+const createDummyUser = async (id: string): Promise<User> => {
+  try {
+    return await db().save(User.dummy(id));
+  } catch (e) {
+    console.log(e);
+    throw LogUtils.logErr(e, { id }, 'Problem creating user');
+  }
+};
+
+const initializeUser = async (
   firstName: string,
   googleID: string,
   lastName: string,
@@ -18,20 +34,10 @@ const initalizeUser = async (
     throw Error('User with given netID already exists');
   }
   const user = db().create({
-    clubs: [],
-    firstName,
-    facebook: null,
     googleID,
-    graduationYear: null,
-    hometown: null,
-    instagram: null,
-    interests: [],
+    firstName,
     lastName,
     netID,
-    major: null,
-    matches: [],
-    profilePictureURL: null,
-    pronouns: null,
   });
   await db().save(user);
   return user;
@@ -52,23 +58,13 @@ const updateUser = async (
 };
 
 const getUserByNetID = async (netID: string): Promise<User | undefined> => {
-  const user = await db().findOne({
-    where: { netID },
-    relations: [
-      'matches',
-      'matches.users',
-      'matches.schedule',
-      'matches.schedule.times',
-      'clubs',
-      'interests',
-      'major',
-    ],
-  });
+  const user = await db().findOne({ netID: netID })
   return user;
 };
 
 export default {
-  initalizeUser,
+  createDummyUser,
+  initializeUser,
   deleteUser,
   getUserByNetID,
   updateUser,

--- a/src/repos/UserRepo.ts
+++ b/src/repos/UserRepo.ts
@@ -16,9 +16,12 @@ const db = (): Repository<User> =>
 */
 const createDummyUser = async (id: string): Promise<User> => {
   try {
-    return await db().save(User.dummy(id));
-  } catch (e) {
-    console.log(e);
+    const dummyUser = User.dummy(id);
+    let user = await getUserByNetID(dummyUser.netID);
+    if (!user) return await db().save(User.dummy(id));
+    return user;
+  }
+  catch (e) {
     throw LogUtils.logErr(e, { id }, 'Problem creating user');
   }
 };

--- a/src/repos/UserSessionRepo.ts
+++ b/src/repos/UserSessionRepo.ts
@@ -21,8 +21,8 @@ const createOrUpdateSession = async (
 ): Promise<UserSession> => {
   let session = await db()
     .createQueryBuilder('usersessions')
-    .innerJoin('usersessions.user', 'user', 'user.netID = :userNetID')
-    .setParameters({ userNetID: user.netID })
+    .innerJoin('usersessions.user', 'user', 'user.uuid = :userID')
+    .setParameters({ userID: user.uuid })
     .getOne();
   if (session) {
     session.update(accessToken);
@@ -60,7 +60,7 @@ const createUserAndInitializeSession = async (
   let user = await UserRepo.getUserByNetID(netID);
 
   if (!user) {
-    user = await UserRepo.initalizeUser(firstName, googleID, lastName, netID);
+    user = await UserRepo.initializeUser(firstName, googleID, lastName, netID);
   }
 
   const session = await createOrUpdateSession(user, undefined);
@@ -122,7 +122,7 @@ const verifySession = async (accessToken: string): Promise<boolean> => {
     .getOne();
   return session
     ? session.active &&
-        session.expiresAt > String(Math.floor(new Date().getTime() / 1000))
+    session.expiresAt > String(Math.floor(new Date().getTime() / 1000))
     : false;
 };
 

--- a/src/routers/InitializeDevSessionRouter.ts
+++ b/src/routers/InitializeDevSessionRouter.ts
@@ -1,0 +1,29 @@
+import { Request } from 'express';
+import { SerializedUserSession } from '../common/types';
+import ApplicationRouter from '../utils/ApplicationRouter';
+import LogUtils from '../utils/LogUtils';
+import UserRepo from '../repos/UserRepo';
+import UserSessionRepo from '../repos/UserSessionRepo';
+
+class InitializeDevSessionRouter extends ApplicationRouter<SerializedUserSession> {
+  constructor() {
+    super('POST');
+  }
+
+  getPath(): string {
+    return '/dev/login/';
+  }
+
+  async content(req: Request): Promise<SerializedUserSession> {
+    if (process.env.NODE_ENV !== 'development') {
+      throw LogUtils.logErr('Must be on development environment to acces this endpoint.');
+    }
+
+    const user = await UserRepo.createDummyUser('googleId');
+    console.log(user);
+    const session = await UserSessionRepo.createOrUpdateSession(user, undefined);
+    return session.serialize();
+  }
+}
+
+export default new InitializeDevSessionRouter().router;

--- a/src/routers/InitializeDevSessionRouter.ts
+++ b/src/routers/InitializeDevSessionRouter.ts
@@ -19,10 +19,14 @@ class InitializeDevSessionRouter extends ApplicationRouter<SerializedUserSession
       throw LogUtils.logErr('Must be on development environment to acces this endpoint.');
     }
 
-    const user = await UserRepo.createDummyUser('googleId');
-    console.log(user);
-    const session = await UserSessionRepo.createOrUpdateSession(user, undefined);
-    return session.serialize();
+    try {
+      const user = await UserRepo.createDummyUser('googleId');
+      const session = await UserSessionRepo.createOrUpdateSession(user, undefined);
+      return session.serialize();
+    }
+    catch (e) {
+      throw Error(e.error.message);
+    }
   }
 }
 

--- a/src/routers/InitializeDevSessionRouter.ts
+++ b/src/routers/InitializeDevSessionRouter.ts
@@ -11,7 +11,7 @@ class InitializeDevSessionRouter extends ApplicationRouter<SerializedUserSession
   }
 
   getPath(): string {
-    return '/dev/login/';
+    return '/login/';
   }
 
   async content(req: Request): Promise<SerializedUserSession> {

--- a/src/routers/UpdateUserRouter.ts
+++ b/src/routers/UpdateUserRouter.ts
@@ -17,7 +17,7 @@ class UpdateUserRouter extends AuthenticatedAppplicationRouter<void> {
   async content(req: Request): Promise<void> {
     const userFields = req.body;
     const userFieldKeys = Object.keys(userFields);
-    const userObjectKeys = Object.keys(req.user);
+    const userObjectKeys = Object.keys(req.user.serialize());
     if (userFieldKeys.length < 1) {
       throw Error('At least one user field is required');
     }
@@ -33,8 +33,8 @@ class UpdateUserRouter extends AuthenticatedAppplicationRouter<void> {
     if (userFields.clubs) {
       userFields.clubs = await Promise.all(
         userFields.clubs.map(async (name: string) => {
-          const club = ClubRepo.getClubByName(name);
-          if (!club) throw Error('CornellMajor with that name not found');
+          const club = await ClubRepo.getClubByName(name);
+          if (!club) throw Error('Club with that name not found');
           return club;
         })
       );
@@ -42,7 +42,7 @@ class UpdateUserRouter extends AuthenticatedAppplicationRouter<void> {
     if (userFields.interests) {
       userFields.interests = await Promise.all(
         userFields.interests.map(async (name: string) => {
-          const interest = InterestRepo.getInterestByName(name);
+          const interest = await InterestRepo.getInterestByName(name);
           if (!interest) throw Error('Interest with that name not found');
           return interest;
         })


### PR DESCRIPTION
## Overview
This PR reformats the User entity to logically associate fields and allow dummy user creation. Dummy user creation is behind a dev-only route, which will allow for self-contained testing for backend without having to prompt iOS for idTokens for google authentication.

## Changes Made
- User entity refactor
- Dummy user creation (dev only endpoint)
- I also have edited the User entity with `ON DELETE CASCADE` conditions to avoid potential catastrophes should we have to delete users because we have multiple relations on this entity.
- We can query using uuid again instead of netID!
- Added missing `await` prompt for async calls.
- Also edited serialization for Users so we can properly query all object keys
  - this includes added an `Undeclared` major constant


## Test Coverage
Tested using Postman and `psql`.

## Next Steps
Start splitting up update endpoint for iOS.
