### PR TITLE
Convert Availability to Many-to-One Relationship

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -48,7 +48,6 @@ export interface SerializedUserSession {
 export type SerializedAvailability = {
   day: string;
   times: number[];
-  users: SubSerializedUser[];
 };
 
 /* Represents a Group */

--- a/src/entities/Availability.ts
+++ b/src/entities/Availability.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, JoinTable, ManyToMany, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, PrimaryGeneratedColumn, ManyToOne } from 'typeorm';
 import { SerializedAvailability } from '../common/types';
 import User from './User';
 
@@ -20,16 +20,14 @@ class Availability {
   })
   times: number[];
 
-  /** Users with this availability */
-  @ManyToMany((type) => User, (user) => user.availabilities)
-  @JoinTable()
-  users: User[];
+  /** User with this availability */
+  @ManyToOne((type) => User, (user) => user.availabilities, { onDelete: 'CASCADE' })
+  user: User;
 
   serialize(): SerializedAvailability {
     return {
       day: this.day,
       times: this.times,
-      users: this.users ? this.users.map((user) => user.subSerialize()) : [],
     };
   }
 }

--- a/src/entities/User.ts
+++ b/src/entities/User.ts
@@ -1,4 +1,4 @@
-import { PrimaryGeneratedColumn, Column, Entity, ManyToMany, ManyToOne } from 'typeorm';
+import { PrimaryGeneratedColumn, Column, Entity, ManyToMany, ManyToOne, OneToMany } from 'typeorm';
 import Constants from '../common/constants';
 import { SerializedUser, SubSerializedUser } from '../common/types';
 import Group from './Group';
@@ -66,7 +66,7 @@ class User {
   profilePictureURL: string | null;
 
   /** User's availabilities */
-  @ManyToMany((type) => Availability, (availability) => availability.users, { onDelete: 'CASCADE' })
+  @OneToMany((type) => Availability, (availability) => availability.user)
   availabilities: Availability[];
 
   /**

--- a/src/repos/AvailabilityRepo.ts
+++ b/src/repos/AvailabilityRepo.ts
@@ -9,7 +9,7 @@ const createAvailability = async (day: string, times: number[]): Promise<Availab
     const availability = db().create({
       day,
       times,
-      users: [],
+      user: null,
     });
     possibleAvailability = await db().save(availability);
   }

--- a/src/repos/AvailabilityRepo.ts
+++ b/src/repos/AvailabilityRepo.ts
@@ -9,7 +9,6 @@ const createAvailability = async (day: string, times: number[]): Promise<Availab
     const availability = db().create({
       day,
       times,
-      user: null,
     });
     possibleAvailability = await db().save(availability);
   }

--- a/src/repos/UserRepo.ts
+++ b/src/repos/UserRepo.ts
@@ -64,14 +64,14 @@ const updateUser = async (user: User, userFields: UserUpdateFields): Promise<boo
 const getUserByNetID = async (netID: string): Promise<User | undefined> => {
   const user = await db().findOne({
     where: { netID },
-    relations: ['availabilities', 'availabilities.users', 'groups', 'interests', 'major'],
+    relations: ['availabilities', 'groups', 'interests', 'major'],
   });
   return user;
 };
 
 const getUsers = async (): Promise<User[]> => {
   return db().find({
-    relations: ['availabilities', 'availabilities.users', 'groups', 'interests', 'major'],
+    relations: ['availabilities', 'groups', 'interests', 'major'],
   });
 };
 

--- a/src/swagger.json
+++ b/src/swagger.json
@@ -910,12 +910,6 @@
               "type": "number",
               "example": 18.5
             }
-          },
-          "users": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/SubUser"
-            }
           }
         }
       },


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->

Decided to convert availability from many-to-many to many-to-one. It was initially a many-to-many relationship since we would be able to pair users with the same times together during matching, but it would consider users that differ by a single 30-minute interval unrelated. Maintaining an extra table on Postgres for the rare cases where users' availabilities happen to be exactly the same is not worth the space wasted since we plan on doing an intersection check for similarity (and using a many-to-many would only benefit by saving us from intersection operations on users we already know have the same exact availabilities, which to reiterate is rare and probably not going to make a large impact in time efficiency).


## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->

- Convert Availability to many-to-one relationship
- Rename users to user in availability
- Remove the user field in Availability serialization since frontend makes no use of it and would require an unnecessary model to be created for subserialized users 
- Update documentation to reflect this

## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

Postman test suite created in my last PR. Below is the updated collections.

[Pear Testing.postman_collection.json.zip](https://github.com/cuappdev/pear-backend/files/5541751/Pear.Testing.postman_collection.json.zip)
