### PR TITLE
Attempt to stop server crashing

### DIFF
--- a/src/repos/UserRepo.ts
+++ b/src/repos/UserRepo.ts
@@ -81,20 +81,7 @@ const getUserByNetID = async (netID: string): Promise<User | undefined> => {
 };
 
 const getUsers = async (): Promise<User[]> => {
-  return db().find({
-    relations: [
-      'availabilities',
-      'goals',
-      'groups',
-      'interests',
-      'major',
-      'matches',
-      'matches.availabilities',
-      'matches.users',
-      'preferredLocations',
-      'talkingPoints',
-    ],
-  });
+  return db().find();
 };
 
 export default {


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->

My current hypothesis is that the excessive amounts of relations on getUsers has been causing massive strain on the server and causing it to crash. I have found issues online ( https://github.com/typeorm/typeorm/issues/3857#issuecomment-609863113 ) related to performance problems that crash servers when using too many relations. One option I considered is replacing `find()` with a `QueryBuilder` equivalent since `find()` loads eager relations (one giant SQL call) while `QueryBuilder` is for lazy relations (multiple SQL calls) but the SQL call printed out to terminal when calling getAllUsers is super big and I'm not that desperate..

Instead, assuming I can run routes that `getUsers()` with this change, I will work on #42 by possibly allowing relations to be explicitly added to the GET request which should reduce the overall amount of relations and strain the server less. Pagination would also be very nice to add in at some point.

## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->

- Remove relations from getUsers


## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

Local testing returned routes calling the `getUsers()` function around 3-4 orders of magnitude for milliseconds before removing the relations and 2 orders of magnitude after removing the relations.

## Next Steps

Assuming server doesn't crash after pushing this, #42 
