### PR TITLE
Revert GetCommunityUserRouter to reflect improved model

### DIFF
--- a/src/routers/GetCommunityUserRouter.ts
+++ b/src/routers/GetCommunityUserRouter.ts
@@ -1,9 +1,9 @@
 import { Request } from 'express';
-import { SerializedUser } from '../common/types';
+import { SerializedCommunityUser } from '../common/types';
 import AuthenticatedApplicationRouter from '../utils/AuthenticatedApplicationRouter';
 import UserRepo from '../repos/UserRepo';
 
-class GetCommunityUserRouter extends AuthenticatedApplicationRouter<SerializedUser> {
+class GetCommunityUserRouter extends AuthenticatedApplicationRouter<SerializedCommunityUser> {
   constructor() {
     super('GET');
   }
@@ -12,22 +12,14 @@ class GetCommunityUserRouter extends AuthenticatedApplicationRouter<SerializedUs
     return '/';
   }
 
-  async content(req: Request): Promise<SerializedUser> {
+  async content(req: Request): Promise<SerializedCommunityUser> {
     const { netID } = req.query;
     const user = await UserRepo.getUserByNetID(netID || req.user.netID, [
       'groups',
       'interests',
       'major',
-      /** Below are properties to remove once iOS refactors */
-      'availabilities',
-      'goals',
-      'matches',
-      'matches.availabilities',
-      'matches.users',
-      'preferredLocations',
-      'talkingPoints',
     ]);
-    return user.serialize();
+    return user.communitySerialize();
   }
 }
 


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->

In #49, the SerializedUser was converted to a SerializedCommunityUser to ensure that the retrieved user models wouldn't be so large and the server wouldn't crash upon requesting a model with so many relations. This would've required lots of work on iOS to modify models, so while `UserRepo.getUsers` was modified we left `UserRepo.getUser` to get all `relations`. This, however, still causes a server crash sometimes so it is necessary to change this back to using less `relations` in order to avoid this.


## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->
- Switch a single user being retrieved with all possible `relations` to only relevant community `relations` and change `serialize()` to `communitySerialize()` accordingly to only send back relevant information.


## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

Postman
