### PR TITLE
Add locations to matching

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -89,6 +89,7 @@ export type SerializedMatch = {
   meetingTime: Date;
   users: string[];
   availabilities: SerializedAvailability[];
+  preferredLocations: SerializedLocation[];
 };
 
 /** Represents a Group */
@@ -147,4 +148,5 @@ export interface MatchUpdateFields {
   status?: string;
   meetingTime?: Date;
   availabilities?: Availability[];
+  preferredLocations?: Location[];
 }

--- a/src/entities/Location.ts
+++ b/src/entities/Location.ts
@@ -1,5 +1,6 @@
 import { Column, Entity, Index, PrimaryGeneratedColumn, ManyToMany, JoinTable } from 'typeorm';
 import { SerializedLocation } from '../common/types';
+import Match from './Match';
 import User from './User';
 
 @Entity('location')
@@ -20,6 +21,11 @@ class Location {
   @ManyToMany((type) => User, (user) => user.preferredLocations)
   @JoinTable()
   users: User[];
+
+  /** Match with this location */
+  @ManyToMany((type) => Match, (match) => match.preferredLocations, { onDelete: 'CASCADE' })
+  @JoinTable()
+  match: Match;
 
   serialize(): SerializedLocation {
     return {

--- a/src/entities/Match.ts
+++ b/src/entities/Match.ts
@@ -1,6 +1,7 @@
 import { Column, Entity, Index, JoinTable, ManyToMany, PrimaryGeneratedColumn } from 'typeorm';
 import { SerializedMatch } from '../common/types';
 import Availability from './Availability';
+import Location from './Location';
 import User from './User';
 
 @Entity('match')
@@ -14,6 +15,9 @@ class Match {
 
   @ManyToMany((type) => Availability, (availability) => availability.match)
   availabilities: Availability[];
+
+  @ManyToMany((type) => Location, (location) => location.match)
+  preferredLocations: Location[];
 
   @Index()
   @Column({ type: 'varchar' })
@@ -30,6 +34,9 @@ class Match {
       users: this.users ? this.users.map((user) => user.netID) : [],
       availabilities: this.availabilities
         ? this.availabilities.map((availability) => availability.serialize())
+        : [],
+      preferredLocations: this.preferredLocations
+        ? this.preferredLocations.map((location) => location.serialize())
         : [],
     };
   }

--- a/src/repos/MatchRepo.ts
+++ b/src/repos/MatchRepo.ts
@@ -28,6 +28,7 @@ const getWeeklyMatchesByNetID = async (netID: string): Promise<Match[]> => {
   const user = await UserRepo.getUserByNetID(netID, [
     'matches',
     'matches.availabilities',
+    'matches.preferredLocations',
     'matches.users',
   ]);
   if (!user) throw Error(`User with netID: '${netID}' doesn't exist in the database.`);

--- a/src/swagger.json
+++ b/src/swagger.json
@@ -482,6 +482,12 @@
                     "items": {
                       "$ref": "#/components/schemas/Availability"
                     }
+                  },
+                  "preferences": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Location"
+                    }
                   }
                 }
               }


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->

<!-- Your title should be able to summarize what changes you've made in one sentence. For example: "Exclude staff from the check for follows". For stacked PRs, please indicate clearly in the title where in the stack you are. For example: "[Eatery Refactor][4/5] Converted all files to MVP model" -->


## Overview

<!-- Summarize your changes here. -->

Location have been added to the /match/availabilities/ route (just add a field `preferred` in addition to whatever used to be there to use and should work similarly to availabilities.


## Changes Made

<!-- Include details of what your changes actually are and how it is intended to work. -->

- Updated Match types
- Added Many to Many relationship between Location and Match
- As always, updated documentation


## Test Coverage

<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

Updated the Postman collections to include locations and successfully set a dummy match to active through the matching process.

[Pear Testing.postman_collection.json.zip](https://github.com/cuappdev/pear-backend/files/6218172/Pear.Testing.postman_collection.json.zip)

NOTE: #54 causes users to not show up when running `/user/all/` so remember to post to `/user/socialMedia/` to see the users (`didOnboard` set to true in the Postman Collection by default).


## Next Steps

<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->

Merge into master AFTER @lucyxubroad has finished implementing this on frontend (otherwise matching will be impossible)